### PR TITLE
Fix release gate workflow trigger configuration

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -1,0 +1,126 @@
+# Release Gate - E2E tests run ONCE at merge to main
+# This workflow runs as a merge queue gate, NOT on every PR update
+#
+# How it works:
+# 1. When a PR is added to the merge queue, this runs E2E tests
+# 2. If tests pass, the PR merges to main
+# 3. If tests fail, the PR is removed from the merge queue
+#
+# Requires: Repository Settings > Branch Protection > Require merge queue
+name: Release Gate
+
+on:
+  # ONLY trigger on merge queue - NOT on pull_request
+  # This ensures E2E tests run exactly once at merge time
+  merge_group:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+  actions: read
+
+concurrency:
+  group: release-gate-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  NODE_VERSION: 25
+  PNPM_VERSION: 10
+
+jobs:
+  # E2E Tests - the release gate
+  # Note: CI has already passed (merge queue pre-check) so we go straight to E2E
+  e2e-tests:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - uses: pnpm/action-setup@9fd676a19091d4595eefd76e4bd31c97133911f1 # v4.2.0
+
+      - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Get Playwright version
+        id: pw-version
+        run: echo "version=$(pnpm list @playwright/test --json | jq -r '.[0].dependencies["@playwright/test"].version // .[0].devDependencies["@playwright/test"].version')" >> $GITHUB_OUTPUT
+
+      - name: Cache Playwright
+        id: pw-cache
+        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.pw-version.outputs.version }}
+
+      - name: Install Playwright
+        if: steps.pw-cache.outputs.cache-hit != 'true'
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Install Playwright deps
+        if: steps.pw-cache.outputs.cache-hit == 'true'
+        run: pnpm exec playwright install-deps chromium
+
+      - name: Run E2E tests
+        id: e2e
+        run: pnpm test:e2e
+
+      - name: Upload report
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 30
+
+  # AI Triage on failure
+  ai-triage:
+    name: AI Triage
+    runs-on: ubuntu-latest
+    needs: e2e-tests
+    if: failure()
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          token: ${{ secrets.CI_GITHUB_TOKEN }}
+
+      - name: Triage failure
+        env:
+          GH_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
+        run: |
+          echo "## ❌ Release Gate E2E Tests Failed"
+          echo ""
+          echo "The merge queue E2E tests failed for this commit."
+          echo "Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          echo ""
+          echo "The PR will be removed from the merge queue."
+
+      # Trigger AI fixer (use merge_group head_ref)
+      - name: Trigger AI Fixer
+        env:
+          GH_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
+        run: |
+          # Extract branch from merge group ref
+          BRANCH="${{ github.event.merge_group.head_ref }}"
+
+          gh workflow run ai-fixer.yml \
+            --ref "$BRANCH" \
+            --repo "${{ github.repository }}" \
+            -f run_id="${{ github.run_id }}" \
+            -f repository="${{ github.repository }}" \
+            -f branch="$BRANCH" || true


### PR DESCRIPTION
This workflow runs E2E tests as a merge queue gate, NOT on every PR update.

Key design decisions:
- Triggers ONLY on merge_group event (not pull_request)
- This ensures E2E tests run exactly once at merge time
- Removes wait-for-ci job since merge queue ensures CI passed
- Uses proper merge_group context for AI fixer on failure

Requires enabling merge queue in Repository Settings > Branch Protection

Fixes firing constantly on every PR update